### PR TITLE
Added publishing steps to the screwdriver config

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,6 +7,7 @@ jobs:
         steps:
             - install: npm install
             - test: npm test
+            - publish: ./scripts/publish
 
     # publish:
     #     steps:

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+if [ -z "$GIT_TOKEN" ] || [ -z "$NPM_TOKEN" ]; then
+  exit 0
+fi
+
 git remote set-url --push origin https://${GIT_TOKEN}@github.com/screwdriver-cd/hashr.git
 npm config set access public
 npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+
+npm run bump
+npm publish && git push origin --tags -q


### PR DESCRIPTION
- This should work as long as secrets are being populated correctly into
  the environment
- Since we don't have workflow yet, we have to publish in main. This
  script just exits if the environment isn't set
