### PR TITLE
Hiding secret configurations

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -1,12 +1,18 @@
 #!/bin/bash -e
 
 if [ -z "$GIT_TOKEN" ] || [ -z "$NPM_TOKEN" ]; then
+  echo Skipping publish in Pull Request
   exit 0
 fi
 
+# Setting up secrets
 git remote set-url --push origin https://${GIT_TOKEN}@github.com/screwdriver-cd/hashr.git
-npm config set access public
-npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+npm config set access public > /dev/null
+npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN} > /dev/null
 
+# Bump the version
 npm run bump
-npm publish && git push origin --tags -q
+# Publish the package
+npm publish
+# Push the new tag to GitHub
+git push origin --tags -q


### PR DESCRIPTION
NPM is super verbose right now, this is what we get (with our secrets):

```
npm info it worked if it ends with ok
npm info using npm@3.10.3
npm info using node@v6.5.0
npm info config set "//registry.npmjs.org/:_authToken" "SECRETTOKENHERE"
npm info ok 
```
